### PR TITLE
[chromeos] Add symlink to debian .bash_local

### DIFF
--- a/chromeos/.bash_local
+++ b/chromeos/.bash_local
@@ -1,0 +1,1 @@
+../debian/.bash_local


### PR DESCRIPTION
When building for chromeos, ensure that .bash_local is symlinked to the
debian version of .bash_local.