### PR TITLE
[debian] Fix .bash_local

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # Environment variables
 
 export DEV_DIR=~/Development

--- a/debian/.bash_local
+++ b/debian/.bash_local
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1090
+
+source "$HOME/Development/dotfiles/common.sh"
 
 # Golang
 export PATH="$PATH:/usr/local/go/bin"
 
 # Java
-export JAVA_HOME="/var/lib/jdk-$JAVA_VERSION/"
+export JAVA_HOME="/var/lib/jdk-$JAVA_VERSION"
 export PATH="$JAVA_HOME/bin:$PATH"
 
 # Rust


### PR DESCRIPTION
The Debian .bash_local relies on a constant defined in common.sh.
Source this in .bash_local.