### PR TITLE
Update Alacritty configuration for macOS

### DIFF
--- a/alacritty/alacritty.yml
+++ b/alacritty/alacritty.yml
@@ -89,9 +89,7 @@ font:
 
   # Normal (roman) font face
   normal:
-    family: "Inconsolata-g for Powerline"
-    # The `style` can be specified to pick a specific face.
-    style: g
+    family: "Inconsolata-dz for Powerline"
 
   # Bold font face
   #bold:


### PR DESCRIPTION
Fix font types to work on macOS.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>