### PR TITLE
Add CA bundle for Git

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -72,3 +72,6 @@
 [gc]
   auto = 50000
   autopacklimit = 500
+
+[http]
+  sslcainfo = ~/.nix-profile/etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
Configure Git to use the CA bundle that ships with Nix.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>